### PR TITLE
fix：修复贴吧表情图片高度与字高不一致，以及只有贴吧表情的贴子底部被截断问题

### DIFF
--- a/app/src/main/java/com/huanchengfly/tieba/post/components/spans/EmotionSpan.java
+++ b/app/src/main/java/com/huanchengfly/tieba/post/components/spans/EmotionSpan.java
@@ -8,10 +8,11 @@ import android.text.style.ImageSpan;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class EmotionSpan extends ImageSpan {
     public static final String TAG = EmotionSpan.class.getSimpleName();
-    private int size;
+    private final int size;
 
     public EmotionSpan(Context context, @DrawableRes int resId, int size) {
         super(context, resId, ALIGN_BASELINE);
@@ -26,12 +27,26 @@ public class EmotionSpan extends ImageSpan {
     }
 
     @Override
+    public int getSize(@NonNull Paint paint, CharSequence text, int start, int end, @Nullable Paint.FontMetricsInt fm) {
+        if (fm != null) {
+            Paint.FontMetricsInt fontFm = paint.getFontMetricsInt();
+
+            fm.ascent = fontFm.top;
+            fm.descent = fontFm.bottom;
+
+            fm.top = fm.ascent;
+            fm.bottom = fm.descent;
+        }
+
+        return size;
+    }
+
+    @Override
     public void draw(@NonNull Canvas canvas, CharSequence text, int start, int end,
                      float x, int top, int y, int bottom, @NonNull Paint paint) {
         Paint.FontMetricsInt fm = paint.getFontMetricsInt();
         Drawable drawable = getDrawable();
-        int transY = (y + fm.descent + y + fm.ascent) / 2
-                - drawable.getBounds().bottom / 2;
+        int transY = y - drawable.getBounds().bottom + fm.descent;
         canvas.save();
         canvas.translate(x, transY);
         drawable.draw(canvas);

--- a/app/src/main/java/com/huanchengfly/tieba/post/utils/StringUtil.java
+++ b/app/src/main/java/com/huanchengfly/tieba/post/utils/StringUtil.java
@@ -3,6 +3,7 @@ package com.huanchengfly.tieba.post.utils;
 import android.content.Context;
 import android.text.Spannable;
 import android.text.SpannableString;
+import android.text.TextPaint;
 import android.text.TextUtils;
 import android.widget.TextView;
 
@@ -32,7 +33,8 @@ public class StringUtil {
                 int start = matcherEmotion.start();
                 int imgRes = EmotionUtil.getImgByName(emotion_map_type, key);
                 if (imgRes != -1) {
-                    int size = (int) tv.getTextSize();
+                    TextPaint paint = tv.getPaint();
+                    int size = Math.round(-paint.ascent() + paint.descent());
                     /*
                     Bitmap bitmap = BitmapFactory.decodeResource(res, imgRes);
                     Bitmap scaleBitmap = Bitmap.createScaledBitmap(bitmap, size, size, true);


### PR DESCRIPTION
根据有人在群里的反馈
![image](https://user-images.githubusercontent.com/22096448/164061889-7fef4106-da60-419c-bcb8-c5bb4c2ace64.png)
