### PR TITLE
修复在api低于24的机器上加载帖子内容出错的bug

### DIFF
--- a/app/src/main/java/com/huanchengfly/tieba/post/api/adapters/ContentMsgAdapter.java
+++ b/app/src/main/java/com/huanchengfly/tieba/post/api/adapters/ContentMsgAdapter.java
@@ -15,11 +15,11 @@ public class ContentMsgAdapter implements JsonDeserializer<List<ThreadContentBea
     public List<ThreadContentBean.ContentBean> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
         List<ThreadContentBean.ContentBean> list = new ArrayList<>();
         if (json.isJsonArray()) {
-            json.getAsJsonArray().forEach(element -> {
+            for (JsonElement element : json.getAsJsonArray()) {
                 if (element.isJsonObject()) {
                     list.add(context.deserialize(element, ThreadContentBean.ContentBean.class));
                 }
-            });
+            }
         }
 
         return list;


### PR DESCRIPTION
我测试的机器是api22

                                      App 版本：4.0.0.dev-10
                                      系统版本：5.1.1
                                      机型：unknown Android SDK built for x86
                                      
                                      崩溃：
                                      java.lang.NoClassDefFoundError: com.huanchengfly.tieba.post.api.adapters.ContentMsgAdapter$$ExternalSyntheticLambda0
at com.huanchengfly.tieba.post.api.adapters.ContentMsgAdapter.deserialize(ContentMsgAdapter.java:18)
at com.huanchengfly.tieba.post.api.adapters.ContentMsgAdapter.deserialize(ContentMsgAdapter.java:13)
at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:69)
at com.google.gson.TypeAdapter$1.read(TypeAdapter.java:199)
at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:130)
at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:221)
at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:41)
at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:82)
at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:61)
at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:130)
at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:221)
at com.huanchengfly.tieba.post.api.retrofit.converter.gson.GsonResponseBodyConverter.convert(GsonResponseBodyConverter.java:27)
at com.huanchengfly.tieba.post.api.retrofit.converter.gson.GsonResponseBodyConverter.convert(GsonResponseBodyConverter.java:14)
at com.huanchengfly.tieba.post.api.retrofit.NullOnEmptyConverterFactory.responseBodyConverter$lambda-0(NullOnEmptyConverterFactory.kt:18)
at com.huanchengfly.tieba.post.api.retrofit.NullOnEmptyConverterFactory.$r8$lambda$gOHAE2hymadNdqSx7OWcn7OAjcw(NullOnEmptyConverterFactory.kt:-1)
at com.huanchengfly.tieba.post.api.retrofit.NullOnEmptyConverterFactory$$ExternalSyntheticLambda0.convert(null:-1)
at retrofit2.OkHttpCall.parseResponse(OkHttpCall.java:243)
at retrofit2.OkHttpCall.execute(OkHttpCall.java:204)
at retrofit2.DefaultCallAdapterFactory$ExecutorCallbackCall.execute(DefaultCallAdapterFactory.java:108)
at com.huanchengfly.tieba.post.utils.preload.loaders.ThreadContentLoader.loadData(ThreadContentLoader.kt:16)
at com.huanchengfly.tieba.post.utils.preload.loaders.ThreadContentLoader.loadData(ThreadContentLoader.kt:7)
at com.billy.android.preloader.Worker.run(Worker.java:209)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
at java.lang.Thread.run(Thread.java:818)